### PR TITLE
ci(release): set status to draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,5 +116,5 @@ jobs:
           packageName: app.mobilemobile.solpan
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: ${{ (contains(github.ref_name, '-alpha') && 'alpha') || (contains(github.ref_name, '-beta') && 'beta') || (contains(github.ref_name, '-test.') && 'internal') || 'production' }}
-          status: ${{ contains(github.ref_name, '-test.') && 'draft' || 'completed' }}
+          status: 'draft'
           whatsNewDirectory: ./play_store_release_notes/ # Use the generated release notes


### PR DESCRIPTION
This commit changes the status of all release types to "draft". This means that releases for alpha, beta, internal, and production tracks will all be created as drafts in the Play Store.