### PR TITLE
feat(ci): add merge queue workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,8 @@ jobs:
       # - name: Run Detekt
       #   run: ./gradlew detekt
 
-      - name: Run Spotless Check
-        run: ./gradlew spotlessCheck --scan
-
-      - name: Run Unit Tests
-        run: ./gradlew testDebugUnitTest --scan
-
-      - name: Build Debug APK for CI
-        run: ./gradlew assembleDebug --scan
+      - name: Run checks and build debug APK
+        run: ./gradlew spotlessCheck :app:testDebugUnitTest :app:assembleDebug --parallel --continue --scan
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -38,8 +38,5 @@ jobs:
         with:
           cache-read-only: false # Allow merge queue runs to write to cache
 
-      - name: Run Unit Tests
-        run: ./gradlew :app:testDebugUnitTest --scan
-
-      - name: Build Debug APK for CI
-        run: ./gradlew :app:assembleDebug --scan
+      - name: Run checks and build debug APK
+        run: ./gradlew :app:testDebugUnitTest :app:assembleDebug --parallel --continue --scan

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,45 @@
+# .github/workflows/merge-queue.yml
+name: Merge Queue Checks
+
+on:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/google-services.json
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false # Allow merge queue runs to write to cache
+
+      - name: Run Unit Tests
+        run: ./gradlew :app:testDebugUnitTest --scan
+
+      - name: Build Debug APK for CI
+        run: ./gradlew :app:assembleDebug --scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,17 +75,8 @@ jobs:
         id: get_version
         run: echo "APP_VERSION_NAME=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV # Removes 'v' prefix from tag for version name
 
-      - name: Build Release AAB
-        run: ./gradlew bundleRelease -PappVersionName=${{ env.APP_VERSION_NAME }} -PappVersionCode=${{ github.run_number }}
-        env:
-          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/release.keystore
-          ANDROID_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          ANDROID_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          # Ensure secrets are set in GitHub: SIGNING_KEY_ALIAS, SIGNING_STORE_PASSWORD, SIGNING_KEY_PASSWORD
-
-      - name: Build Release APK
-        run: ./gradlew assembleRelease -PappVersionName=${{ env.APP_VERSION_NAME }} -PappVersionCode=${{ github.run_number }}
+      - name: Build Release Artifacts (AAB and APK)
+        run: ./gradlew :app:bundleRelease :app:assembleRelease -PappVersionName=${{ env.APP_VERSION_NAME }} -PappVersionCode=${{ github.run_number }} --parallel --continue --scan
         env:
           ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/release.keystore
           ANDROID_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for the merge queue.

The workflow performs the following steps:
- Checks out the code
- Sets up JDK 17
- Decodes the `google-services.json` file from secrets
- Grants execute permission to the Gradle wrapper
- Sets up Gradle with caching
- Runs unit tests
- Builds a debug APK