### PR TITLE
ci: Fix merge queue concurrency

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The previous concurrency group using `github.head_ref` was not correctly cancelling in-progress jobs when new commits were pushed to a PR in the merge queue.

Changing to `github.ref` ensures that the concurrency group is unique to the merge group's temporary branch, allowing for proper cancellation and preventing unnecessary runs.