### PR TITLE
ci: add write permission for checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -51,7 +54,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: success() || failure()
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change adds the `checks: write` permission to the GitHub Actions workflows for `build.yml` and `merge-queue.yml`.

This is necessary for the `mikepenz/action-junit-report` action to publish test results as checks.