### PR TITLE
feat: Add per-app language preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,11 @@ android {
     }
   }
 
+  @Suppress("UnstableApiUsage")
+  androidResources {
+    generateLocaleConfig = true
+  }
+
   buildTypes {
     release {
       isMinifyEnabled = true

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2025 MobileMobile LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+#
+
+unqualifiedResLocale=en-US


### PR DESCRIPTION
This commit enables per-app language preferences by configuring the `generateLocaleConfig` property in the `app/build.gradle.kts` file. It also adds a `resources.properties` file to specify `en-US` as the default unqualified resource locale.