### PR TITLE
ci: Configure Gradle cache encryption and remove redundant JDK setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Decode google-services.json
         env:
@@ -43,6 +38,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       # - name: Run Detekt
       #   run: ./gradlew detekt

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -18,14 +18,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Decode google-services.json
         env:
@@ -40,6 +35,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false # Allow merge queue runs to write to cache
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Run checks and build debug APK
         run: ./gradlew :app:testDebugUnitTest :app:assembleDebug --parallel --continue --scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for changelog generation
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Decode google-services.json
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
@@ -47,6 +39,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Generate Changelog
         id: generate_changelog


### PR DESCRIPTION
The redundant `Set up JDK 17` step is removed from the GitHub Actions workflows as `actions/setup-gradle` already handles JDK setup.

The Gradle build cache is now configured with an encryption key using `secrets.GRADLE_CACHE_ENCRYPTION_KEY` in all workflows to enhance security.