### PR TITLE
ci: Add SLSA provenance attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ concurrency:
 
 permissions:
   checks: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,8 @@ jobs:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'app/build/outputs/apk/debug/app-debug.apk'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ concurrency:
 permissions:
   contents: write
   pull-requests: read
+  id-token: write
+  attestations: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'app/build/outputs/apk/debug/app-debug.*'
+
       - name: Upload AAB to Google Play
         if: success() && github.ref_type == 'tag'
         uses: r0adkll/upload-google-play@v1


### PR DESCRIPTION
This commit adds a step to both the build and release workflows to generate SLSA (Supply-chain Levels for Software Artifacts) provenance attestations for the produced APK.

This helps ensure the integrity and security of the build process.