### PR TITLE
feat(i18n): add locale filters to app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,6 @@ android {
         targetSdk = 36
         versionCode = (findProperty("appVersionCode") as String? ?: "1").toInt()
         versionName = findProperty("appVersionName") as String? ?: "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -56,7 +55,39 @@ android {
     }
 
     @Suppress("UnstableApiUsage")
-    androidResources { generateLocaleConfig = true }
+    androidResources {
+        generateLocaleConfig = true
+        localeFilters.addAll(
+            listOf(
+                "ar",
+                "b+es+419",
+                "cs",
+                "de",
+                "en",
+                "es",
+                "fr",
+                "hi",
+                "hu",
+                "id",
+                "it",
+                "iw",
+                "ja",
+                "ko",
+                "no",
+                "pl",
+                "pt",
+                "ro",
+                "ru",
+                "sk",
+                "sv",
+                "th",
+                "tr",
+                "uk",
+                "vi",
+                "zh-rCN",
+            ),
+        )
+    }
 
     buildTypes {
         release {


### PR DESCRIPTION
This commit adds a list of locale filters to the `androidResources` block in the `app/build.gradle.kts` file. This will ensure that only the specified locales are included in the final APK, reducing the app size.