### PR TITLE
chore(renovate): configure automerge and group dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,35 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "description": "Automerge minor and patch updates after CI passes",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr-awaiting-status"
+    },
+    {
+      "description": "Group Kotlin and Android Gradle Plugin updates",
+      "matchPackagePatterns": [
+        "^com.android.tools.build:gradle",
+        "^org.jetbrains.kotlin.",
+        "^com.google.devtools.ksp"
+      ],
+      "groupName": "kotlin & agp"
+    },
+    {
+      "description": "Group all Jetpack packages",
+      "matchPackagePatterns": [
+        "^androidx."
+      ],
+      "groupName": "androidx"
+    },
+    {
+      "description": "Do not automerge unstable pre-release versions",
+      "matchNewVersion": "/-alpha|-beta|-rc/",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
This commit introduces several changes to the Renovate configuration:

- Enables automerge for minor and patch updates when the current version is not a pre-release (0.x) and CI passes. The `automergeType` is set to `pr-awaiting-status`.
- Creates a group for Kotlin, Android Gradle Plugin, and KSP updates.
- Creates a group for all AndroidX Jetpack packages.
- Disables automerge for unstable pre-release versions (alpha, beta, rc).