### PR TITLE
chore(deps): disable automerge for unstable pre-releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,9 @@
     },
     {
       "description": "Do not automerge unstable pre-release versions",
+      "matchPackagePatterns": [
+        "*"
+      ],
       "matchNewVersion": "/-alpha|-beta|-rc/",
       "automerge": false
     }


### PR DESCRIPTION
This commit updates the Renovate configuration to disable automerging for all packages when the new version is a pre-release (alpha, beta, or rc).