### PR TITLE
chore(deps): Configure Renovate to automerge passing PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
-      "automergeType": "pr-awaiting-status"
+      "automergeType": "pr",
+      "ignoreTests": false
     },
     {
       "description": "Group Kotlin and Android Gradle Plugin updates",


### PR DESCRIPTION
Updates the Renovate configuration to change the `automergeType` from `pr-awaiting-status` to `pr`. This means that PRs will be merged automatically if all status checks pass.

Additionally, `ignoreTests` is explicitly set to `false` for this package rule, ensuring that tests are considered before automerging.