### PR TITLE
fix(SolPanViewModel): ensure correct ViewModel class in Factory

### DIFF
--- a/app/src/main/java/app/mobilemobile/solpan/SolPanViewModel.kt
+++ b/app/src/main/java/app/mobilemobile/solpan/SolPanViewModel.kt
@@ -45,7 +45,13 @@ class SolPanViewModel(
     class Factory(
         private val key: SolPan,
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = SolPanViewModel(key) as T
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(SolPanViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return SolPanViewModel(key) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+        }
     }
 
     private val _currentLocation = MutableStateFlow<LocationData?>(null)


### PR DESCRIPTION
The ViewModelProvider.Factory in SolPanViewModel now explicitly checks if the requested modelClass is assignable from SolPanViewModel. This prevents potential ClassCastExceptions if an incorrect ViewModel class is requested.