### PR TITLE
chore: update Proguard rules for kotlinx.serialization

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,8 @@
 # R8 warning workaround for the suncalc library, which uses compile-only
 # findbugs annotations that are not included in the final artifact.
 -dontwarn edu.umd.cs.findbugs.annotations.**
+
+# R8 warning workaround for kotlinx.serialization library
+-keepnames class kotlinx.serialization.internal.*Serializer* {
+    <init>(...);
+}


### PR DESCRIPTION
Adds a Proguard rule to keep the names of classes in `kotlinx.serialization.internal` that end with "Serializer" and have a constructor. This resolves R8 warnings related to the kotlinx.serialization library.